### PR TITLE
change text to public restroom

### DIFF
--- a/src/lib/details.svelte
+++ b/src/lib/details.svelte
@@ -28,8 +28,8 @@
       class="image"
       src="https://www.nycgovparks.org/common_images/img/restroom.gif"
     />
-    <h3 class="text-xl font-base">Comfort Station</h3>
-    A restroom icon indicates that the playground includes a comfort station.
+    <h3 class="text-xl font-base">Public restroom</h3>
+    A restroom icon indicates that the playground includes a Public restroom.
   </div>
   <div class="row mt-2 mb-4 flex-1">
     <img
@@ -37,8 +37,8 @@
       class="image"
       src="https://www.nycgovparks.org/common_images/img/restroom_accessible.gif"
     />
-    <h3 class="text-xl font-base">ADA Accessible Comfort Station</h3>
-    A restroom icon with a wheelchair indicates that the comfort station meets the
+    <h3 class="text-xl font-base">ADA Accessible public restroom</h3>
+    A restroom icon with a wheelchair indicates that the public restroom meets the
     standards of the Americans with Disabilities Act
   </div>
 </div>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -15,14 +15,14 @@ export const filters = [
     fieldName: "accessible",
   },
   {
-    name: "Comfort stations",
+    name: "Public restroom",
     color: "#5394ac",
     checked: false,
     icon: "https://www.nycgovparks.org/common_images/img/restroom.gif",
     fieldName: "comfort_station",
   },
   {
-    name: "ADA accessible comfort stations",
+    name: "ADA accessible public restroom",
     color: "#00729d",
     checked: false,
     icon: "https://www.nycgovparks.org/common_images/img/restroom_accessible.gif",


### PR DESCRIPTION
https://gothamist.com/news/nyc-parks-will-bar-comfort-station-term-over-link-to-wwii-sex-slavery